### PR TITLE
Add Gem 'rails-timeago', '~> 2.0'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -475,6 +475,9 @@ GEM
     rails-i18n (6.0.0)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 7)
+    rails-timeago (2.20.0)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
     railties (6.0.6.1)
       actionpack (= 6.0.6.1)
       activesupport (= 6.0.6.1)
@@ -743,6 +746,7 @@ DEPENDENCIES
   puma (~> 4.3.12)
   rails (= 6.0.6.1)
   rails-assets-markdown-it (~> 9.0.1)!
+  rails-timeago (~> 2.0)
   recipient_interceptor (~> 0.3.1)
   redcarpet (~> 3.5.1)
   responders (~> 3.0.1)

--- a/Gemfile_custom
+++ b/Gemfile_custom
@@ -25,3 +25,5 @@
 # Add your custom gem dependencies here
 
 gem 'cookies_eu'
+
+gem 'rails-timeago', '~> 2.0'

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Translation ready in dozens of languages
 Changing the way debates votes are showed to the users. 
 Show total votes instead of vote score
 
+- Add Gem 'rails-timeago', '~> 2.0'
+Format the date in a pretty way ( 1 days ago, 1 month ago)
+Translation ready in dozens of languages
+Changes in views for Debates, Proposals and Comments
+[gem 'rails-timeago'](https://github.com/jgraichen/rails-timeago)
+
+
 ## Run Locally
 
 Clone the project

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -114,7 +114,12 @@
 //= require_tree ./admin
 //= require_tree ./sdg
 //= require_tree ./sdg_management
+
 //= require cookies_eu
+
+//= require rails-timeago
+//= require rails-timeago-all
+
 //= require custom
 //= require_tree ./custom
 

--- a/app/views/custom/comments/_comment.html.erb
+++ b/app/views/custom/comments/_comment.html.erb
@@ -1,0 +1,113 @@
+<% valuation = local_assigns.fetch(:valuation, false) %>
+<% cache [locale_and_user_status(comment), comment, commentable_cache_key(comment.commentable), comment.author] do %>
+  <div id="<%= dom_id(comment) %>" class="comment small-12">
+    <div class="comment-body">
+      <% if comment.hidden? %>
+        <% if comment.children.size > 0 %>
+          <div class="callout secondary">
+            <p><%= t("comments.comment.deleted") %></p>
+          </div>
+        <% end %>
+      <% else %>
+        <% if comment.as_administrator? %>
+          <%= image_tag("avatar_admin.png", size: 32, class: "admin-avatar float-left") %>
+        <% elsif comment.as_moderator? %>
+          <%= image_tag("avatar_moderator.png", size: 32, class: "moderator-avatar float-left") %>
+        <% else %>
+        <% if comment.user.hidden? || comment.user.erased? %>
+            <span class="icon-deleted user-deleted"></span>
+          <% elsif comment.user.organization? %>
+            <%= image_tag("avatar_collective.png", size: 32, class: "avatar float-left") %>
+          <% else %>
+            <%= avatar_image(comment.user, seed: comment.user_id, size: 32, class: "float-left") %>
+          <% end %>
+        <% end %>
+
+        <div class="comment-info">
+
+          <% if comment.as_administrator? %>
+            <span class="user-name">
+              <%= t("comments.comment.admin") %>
+              <% if valuation %>
+                <%= Administrator.find(comment.administrator_id).description_or_name %>
+              <% else %>
+                #<%= comment.administrator_id %>
+              <% end %>
+            </span>
+          <% elsif comment.as_moderator? %>
+            <span class="user-name"><%= t("comments.comment.moderator") %> #<%= comment.moderator_id %></span>
+          <% else %>
+
+            <% if comment.user.hidden? || comment.user.erased? %>
+              <span class="user-name"><%= t("comments.comment.user_deleted") %></span>
+            <% else %>
+              <span class="user-name"><%= link_to comment.user.name, user_path(comment.user) %></span>
+              <% if comment.user.display_official_position_badge? %>
+                &nbsp;&bull;&nbsp;
+                <span class="label round level-<%= comment.user.official_level %>">
+                  <%= comment.user.official_position %>
+                </span>
+              <% end %>
+            <% end %>
+            <% if comment.user.verified_organization? %>
+              &nbsp;&bull;&nbsp;
+              <span class="label round is-association">
+                <%= t("shared.collective") %>
+              </span>
+            <% end %>
+            <% if comment.user_id == comment.commentable.author_id %>
+              &nbsp;&bull;&nbsp;
+              <span class="label round is-author">
+                <%= t("comments.comment.author") %>
+              </span>
+            <% end %>
+
+          <% end %>
+
+          &nbsp;&bull;&nbsp;
+          <span>
+            <%= link_to comment_path(comment) do %>
+              <%= timeago_tag comment.created_at.to_date, force: true, lang: I18n.locale, title:"#{comment.created_at.to_date}"  %> 
+            <% end %>
+          </span>
+        </div>
+
+        <div class="comment-user
+                  <%= user_level_class comment %>
+                  <%= comment_author_class comment, comment.commentable.author_id %>">
+          <%= simple_format sanitize_and_auto_link(comment.body), {}, sanitize: false %>
+        </div>
+
+        <div id="<%= dom_id(comment) %>_reply" class="reply">
+          <% unless valuation %>
+            <div id="<%= dom_id(comment) %>_votes" class="comment-votes float-right">
+              <%= render "comments/votes", comment: comment %>
+            </div>
+          <% end %>
+
+          <span class="responses-count">
+            <%= render "comments/responses_count", count: comment.children.size %>
+          </span>
+
+          <% if user_signed_in? && !comments_closed_for_commentable?(comment.commentable) && !require_verified_resident_for_commentable?(comment.commentable, current_user) %>
+            <span class="divider">&nbsp;|&nbsp;</span>
+            <%= link_to(comment_link_text(comment), "",
+                        class: "js-add-comment-link", data: { id: dom_id(comment) }) %>
+
+            <% unless valuation %>
+              <%= render "comments/actions", { comment: comment } %>
+            <% end %>
+
+            <% if !valuation || can?(:comment_valuation, comment.commentable) %>
+              <%= render "comments/form", { commentable: comment.commentable,
+                                           parent_id: comment.id,
+                                           valuation: valuation } %>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <%= render "comments/comment_list", comments: child_comments_of(comment), valuation: valuation %>
+  </div>
+<% end %>

--- a/app/views/custom/debates/_debate.html.erb
+++ b/app/views/custom/debates/_debate.html.erb
@@ -1,0 +1,58 @@
+<% cache [locale_and_user_status, debate, current_user&.voted_as_when_voted_for(debate)] do %>
+  <div id="<%= dom_id(debate) %>" class="debate clear" data-type="debate">
+    <div class="panel">
+      <div class="row">
+
+        <div class="small-12 medium-9 column">
+          <div class="debate-content">
+            <h3><%= link_to debate.title, debate %></h3>
+            <p class="debate-info">
+              <%= timeago_tag debate.created_at.to_date, force: true, lang: I18n.locale, title:"#{debate.created_at.to_date}"  %> 
+              <span class="bullet">&nbsp;&bull;&nbsp;</span>
+              <%= render Shared::CommentsCountComponent.new(
+                debate.comments_count,
+                url: debate_path(debate, anchor: "comments")
+              ) %>
+
+              <% if debate.author.hidden? || debate.author.erased? %>
+                <span class="bullet">&nbsp;&bull;&nbsp;</span>
+                <span class="author">
+                  <%= t("debates.show.author_deleted") %>
+                </span>
+              <% else %>
+                <span class="bullet">&nbsp;&bull;&nbsp;</span>
+                <span class="author">
+                  <%= debate.author.name %>
+                </span>
+                <% if debate.author.display_official_position_badge? %>
+                  <span class="bullet">&nbsp;&bull;&nbsp;</span>
+                  <span class="label round level-<%= debate.author.official_level %>">
+                    <%= debate.author.official_position %>
+                  </span>
+                <% end %>
+              <% end %>
+
+              <% if debate.author.verified_organization? %>
+                <span class="bullet">&nbsp;&bull;&nbsp;</span>
+                <span class="label round is-association">
+                  <%= t("shared.collective") %>
+                </span>
+              <% end %>
+
+            </p>
+            <div class="debate-description">
+              <%= wysiwyg(debate.description) %>
+              <div class="truncate"></div>
+            </div>
+            <%= render "shared/tags", taggable: debate, limit: 5 %>
+          </div>
+        </div>
+
+        <div id="<%= dom_id(debate) %>_votes" class="small-12 medium-3 column">
+            <%= render "debates/votes", debate: debate %>
+        </div>
+
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/custom/debates/show.html.erb
+++ b/app/views/custom/debates/show.html.erb
@@ -1,0 +1,73 @@
+<% provide :title do %><%= @debate.title %><% end %>
+<% content_for :canonical do %>
+  <%= render "shared/canonical", href: debate_url(@debate) %>
+<% end %>
+
+<% cache [locale_and_user_status(@debate),
+          @debate,
+          @debate.author,
+          Flag.flagged?(current_user, @debate),
+          current_user&.voted_as_when_voted_for(@debate)] do %>
+  <div class="debate-show">
+    <div id="<%= dom_id(@debate) %>" class="row">
+      <div class="small-12 medium-9 column">
+        <%= back_link_to %>
+
+        <h1><%= @debate.title %></h1>
+        <% if @debate.conflictive? %>
+          <div data-alert class="callout alert margin-top">
+            <strong><%= t("debates.show.flag") %></strong>
+          </div>
+        <% end %>
+
+        <div class="debate-info">
+          <%= render "/shared/author_info", resource: @debate %>
+
+          <span class="bullet">&nbsp;&bull;&nbsp;</span>
+          <%= timeago_tag @debate.created_at.to_date, force: true, lang: I18n.locale, title:"#{@debate.created_at.to_date}" %> 
+          <span class="bullet">&nbsp;&bull;&nbsp;</span>
+          <%= render Shared::CommentsCountComponent.new(@debate.comments_count, url: "#comments") %>
+          <span class="bullet">&nbsp;&bull;&nbsp;</span>
+          <span class="js-flag-actions">
+            <%= render "shared/flag_actions", flaggable: @debate %>
+          </span>
+        </div>
+
+        <%= auto_link_already_sanitized_html wysiwyg(@debate.description) %>
+
+        <%= render "shared/tags", taggable: @debate %>
+
+        <%= render "relationable/related_content", relationable: @debate %>
+
+        <div class="js-moderator-debate-actions margin">
+          <%= render "actions", debate: @debate %>
+        </div>
+      </div>
+
+      <aside class="small-12 medium-3 column">
+        <% if current_user && @debate.editable_by?(current_user) %>
+          <div class="sidebar-divider"></div>
+          <h2><%= t("debates.show.author") %></h2>
+          <%= link_to edit_debate_path(@debate), class: "button hollow expanded" do %>
+            <span class="icon-edit"></span>
+            <%= t("debates.show.edit_debate_link") %>
+          <% end %>
+        <% end %>
+
+        <div class="sidebar-divider"></div>
+        <h2><%= t("votes.supports") %></h2>
+        <div id="<%= dom_id(@debate) %>_votes">
+          <%= render "debates/votes", debate: @debate %>
+        </div>
+        <%= render "shared/social_share",
+          share_title: t("debates.show.share"),
+          title: @debate.title,
+          url: debate_url(@debate),
+          description: @debate.title,
+          mobile: @debate.title %>
+      </aside>
+    </div>
+  </div>
+<% end %>
+
+<%= render "comments" %>

--- a/app/views/custom/proposals/_info.html.erb
+++ b/app/views/custom/proposals/_info.html.erb
@@ -1,0 +1,75 @@
+<div class="proposal-info">
+  <%= render "/shared/author_info", resource: @proposal %>
+
+  <span class="bullet">&nbsp;&bull;&nbsp;</span>
+  <%= timeago_tag @proposal.created_at.to_date, force: true, lang: I18n.locale, title:"#{@proposal.created_at.to_date}"  %> 
+
+  <% unless @proposal.selected? %>
+    <span class="bullet">&nbsp;&bull;&nbsp;</span>
+    <%= render Shared::CommentsCountComponent.new(@proposal.comments_count, url: "#comments") %>
+  <% end %>
+
+  <% if current_user %>
+    <span class="bullet">&nbsp;&bull;&nbsp;</span>
+    <span class="js-flag-actions">
+      <%= render "shared/flag_actions", flaggable: @proposal %>
+    </span>
+  <% end %>
+
+</div>
+
+<%= render_image(@proposal.image, :large, true) if @proposal.image.present? %>
+
+<br>
+<% unless @proposal.selected? %>
+  <p>
+    <%= t("proposals.show.code") %>
+    <strong><%= @proposal.code %></strong>
+  </p>
+<% end %>
+
+<blockquote><%= @proposal.summary %></blockquote>
+
+<% if @proposal.video_url.present? %>
+  <div class="small-12 medium-7 small-centered">
+    <div class="flex-video">
+      <div id="js-embedded-video" data-video-code="<%= embedded_video_code(@proposal) %>"></div>
+    </div>
+  </div>
+<% end %>
+
+<%= auto_link_already_sanitized_html wysiwyg(@proposal.description) %>
+
+<% if feature?(:map) && map_location_available?(@proposal.map_location) %>
+  <div class="margin">
+    <%= render_map(@proposal.map_location, "proposal", false, nil) %>
+  </div>
+<% end %>
+
+<% if @proposal.video_url.present? %>
+  <div class="video-link">
+    <p>
+      <span class="icon-video"></span>&nbsp;
+      <strong><%= t("proposals.show.title_video_url") %></strong>
+    </p>
+    <%= sanitize_and_auto_link @proposal.video_url %>
+  </div>
+<% end %>
+
+<% if @proposal.retired? %>
+  <div id="retired_explanation" class="callout">
+    <h2>
+      <%= t("proposals.show.retired") %>:
+      <%= t("proposals.retire_options.#{@proposal.retired_reason}") unless @proposal.retired_reason == "other" %>
+    </h2>
+    <%= simple_format sanitize_and_auto_link(@proposal.retired_explanation), {}, sanitize: false %>
+  </div>
+<% end %>
+
+<% if feature?(:allow_attached_documents) %>
+  <%= render "documents/documents",
+              documents: @proposal.documents,
+              max_documents_allowed: Proposal.max_documents_allowed %>
+<% end %>
+
+<%= render "shared/tags", taggable: @proposal %>

--- a/app/views/custom/proposals/_proposal.html.erb
+++ b/app/views/custom/proposals/_proposal.html.erb
@@ -1,0 +1,87 @@
+<div id="<%= dom_id(proposal) %>"
+     class="proposal clear
+            <%= ("successful" if proposal.total_votes > Proposal.votes_needed_for_success) %>"
+     data-type="proposal">
+  <div class="panel <%= "with-image" if proposal.image.present? %>">
+    <div class="icon-successful"></div>
+
+    <% if proposal.image.present? %>
+      <div class="row">
+        <div class="small-12 medium-3 large-2 column text-center">
+          <%= image_tag proposal.image.variant(:thumb),
+                        alt: proposal.image.title.unicode_normalize %>
+        </div>
+
+        <div class="<%= css_for_proposal_info_row(proposal) %>">
+    <% else %>
+      <div class="row">
+        <div class="<%= css_for_proposal_info_row(proposal) %>">
+      <% end %>
+        <div class="proposal-content">
+          <% cache [locale_and_user_status(proposal), "index", proposal, proposal.author] do %>
+            <h3><%= link_to proposal.title, namespaced_proposal_path(proposal) %></h3>
+            <p class="proposal-info">
+              <%= timeago_tag proposal.created_at.to_date, force: true, lang: I18n.locale, title:"#{proposal.created_at.to_date}"  %> 
+              <span class="bullet">&nbsp;&bull;&nbsp;</span>
+              <%= render Shared::CommentsCountComponent.new(
+                proposal.comments_count,
+                url: namespaced_proposal_path(proposal, anchor: "comments")
+              ) %>
+
+              <% if proposal.author.hidden? || proposal.author.erased? %>
+                <span class="bullet">&nbsp;&bull;&nbsp;</span>
+                <span class="author">
+                  <%= t("proposals.show.author_deleted") %>
+                </span>
+              <% else %>
+                <span class="bullet">&nbsp;&bull;&nbsp;</span>
+                <span class="author">
+                  <%= proposal.author.name %>
+                </span>
+                <% if proposal.author.display_official_position_badge? %>
+                  <span class="bullet">&nbsp;&bull;&nbsp;</span>
+                  <span class="label round level-<%= proposal.author.official_level %>">
+                    <%= proposal.author.official_position %>
+                  </span>
+                <% end %>
+              <% end %>
+
+              <% if proposal.author.verified_organization? %>
+                <span class="bullet">&nbsp;&bull;&nbsp;</span>
+                <span class="label round is-association">
+                  <%= t("shared.collective") %>
+                </span>
+              <% end %>
+            </p>
+            <div class="proposal-description">
+              <p><%= proposal.summary %></p>
+              <div class="truncate"></div>
+            </div>
+            <%= render "shared/tags", taggable: proposal, limit: 5 %>
+          <% end %>
+        </div>
+      </div>
+
+      <% if show_proposal_votes? %>
+        <div id="<%= dom_id(proposal) %>_votes"
+             class="small-12 medium-3 column supports-container">
+          <% if proposal.successful? %>
+            <div class="padding">
+              <div class="supports text-center">
+                <%= render "proposals/supports", proposal: proposal %>
+              </div>
+            </div>
+          <% elsif proposal.archived? %>
+            <div class="padding text-center">
+              <strong><%= t("proposals.proposal.supports", count: proposal.total_votes) %></strong>
+              <p><%= t("proposals.proposal.archived") %></p>
+            </div>
+          <% else %>
+            <%= render "votes", proposal: proposal %>
+          <% end %>
+        </div>
+      <% end %>
+
+    </div>
+  </div>
+</div>


### PR DESCRIPTION

## Objectives

> What are the objectives of these changes?

- Add Gem 'rails-timeago', '~> 2.0'
Format the date in a pretty way ( 1 days ago, 1 month ago)
Translation ready in dozens of languages
Changes in views for Debates, Proposals and Comments
[gem 'rails-timeago'](https://github.com/jgraichen/rails-timeago)

## Visual Changes
showing Xtime ago text and using the full date as "title"

> Any visual changes? please attach screenshots (or gifs) showing them.
> If modified views are public (not the admin panel), try them in mobile display (with your browser's developer console) and add screenshots.
![image](https://user-images.githubusercontent.com/114252883/232690587-67b7f9d5-222f-4cfd-8354-4e4d0b45403b.png)
![image](https://user-images.githubusercontent.com/114252883/232690620-d6954b75-ab4f-4ca0-b1c7-0f234eb7b716.png)

