### PR TITLE
Fix capybara console issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,8 @@ end
 
 group :test do
   gem "capybara", "~> 3.37.1"
-  gem "capybara-webmock", "~> 0.6.0"
+  # capybara-webmock to be updated to the latest gem version when available
+  gem "capybara-webmock", git: "https://github.com/hashrocket/capybara-webmock"
   gem "email_spec", "~> 2.2.0"
   gem "rspec-rails", "~> 5.1.2"
   gem "selenium-webdriver", "~> 3.142"

--- a/Gemfile
+++ b/Gemfile
@@ -85,11 +85,11 @@ end
 
 group :test do
   gem "capybara", "~> 3.37.1"
-  # capybara-webmock to be updated to the latest gem version when available
+  # capybara-webmock to be updated to the latest gem version when available https://github.com/hashrocket/capybara-webmock/pull/50
   gem "capybara-webmock", git: "https://github.com/hashrocket/capybara-webmock"
   gem "email_spec", "~> 2.2.0"
   gem "rspec-rails", "~> 5.1.2"
-  gem "selenium-webdriver", "~> 3.142"
+  gem "selenium-webdriver", "~> 4.10.0"
   gem "simplecov", "~> 0.21.2", require: false
   gem "simplecov-lcov", "~> 0.8.0", require: false
   gem "webdrivers", "~> 4.7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/hashrocket/capybara-webmock
+  revision: d3f3b7c8edbeca7b575e74b256ad22df80d2b420
+  specs:
+    capybara-webmock (0.6.0)
+      capybara (>= 2.4, < 4)
+      rack (>= 1.4)
+      rack-proxy (>= 0.6.0)
+      rexml (>= 3.2)
+      selenium-webdriver (>= 4.0)
+      webrick (>= 1.7)
+
 GEM
   remote: https://rails-assets.org/
   specs:
@@ -133,13 +145,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    capybara-webmock (0.6.0)
-      capybara (>= 2.4, < 4)
-      rack (>= 1.4)
-      rack-proxy (>= 0.6.0)
-      rexml (>= 3.2)
-      selenium-webdriver (~> 3.0)
-      webrick (>= 1.7)
     caxlsx (3.2.0)
       htmlentities (~> 4.3, >= 4.3.4)
       marcel (~> 1.0)
@@ -149,7 +154,6 @@ GEM
       actionpack (>= 3.1)
       caxlsx (>= 3.0)
     chef-utils (16.4.41)
-    childprocess (3.0.0)
     chronic (0.10.2)
     ckeditor (4.3.0)
       orm_adapter (~> 0.5.0)
@@ -444,7 +448,7 @@ GEM
       rack (>= 0.4)
     rack-protection (2.2.2)
       rack
-    rack-proxy (0.7.0)
+    rack-proxy (0.7.6)
       rack
     rack-test (2.0.2)
       rack (>= 1.3)
@@ -576,9 +580,10 @@ GEM
       faraday (>= 0.17.3, < 3)
     scss_lint (0.59.0)
       sass (~> 3.5, >= 3.5.5)
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
+    selenium-webdriver (4.10.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -651,7 +656,8 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (> 3.141, < 5.0)
-    webrick (1.7.0)
+    webrick (1.8.1)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -685,7 +691,7 @@ DEPENDENCIES
   capistrano3-delayed-job (~> 1.7.6)
   capistrano3-puma (~> 5.2.0)
   capybara (~> 3.37.1)
-  capybara-webmock (~> 0.6.0)
+  capybara-webmock!
   caxlsx (~> 3.2.0)
   caxlsx_rails (~> 0.6.3)
   ckeditor (~> 4.3.0)
@@ -752,7 +758,7 @@ DEPENDENCIES
   sassc-rails (~> 2.1.2)
   savon (~> 2.13.0)
   scss_lint (~> 0.59.0)
-  selenium-webdriver (~> 3.142)
+  selenium-webdriver (~> 4.10.0)
   simplecov (~> 0.21.2)
   simplecov-lcov (~> 0.8.0)
   sitemap_generator (~> 6.3.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,7 +54,7 @@ end
 FactoryBot.use_parent_strategy = false
 
 Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+  capabilities = Selenium::WebDriver::Options.chrome(
     "goog:chromeOptions" => {
       args: %W[headless no-sandbox window-size=1200,800 proxy-server=#{Capybara.app_host}:#{Capybara::Webmock.port_number}]
     }


### PR DESCRIPTION
## References

https://github.com/netoum/meetdemocracy-consul/issues/8

## Objectives

Fix console error when running rspec tests

## Visual Changes

No more console error when running tests
`/.rbenv/versions/3.0.6/lib/ruby/gems/3.0.0/gems/capybara-webmock-0.6.0/lib/capybara/webmock.rb:155: warning: File.exists? is deprecated; use File.exist? instead
`

## Notes

  capybara-webmock to be updated to the latest gem version when available 
  https://rubygems.org/gems/capybara-webmock
  Last update was 2021 but the author seems active on github 

